### PR TITLE
adjusted config.toml to reference actual github URLs of rqlite.io and rqlite

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -104,9 +104,9 @@ version = "0.0"
 #url_latest_version = "https://example.com"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/google/docsy-example"
+github_repo = "https://github.com/rqlite/rqlite.io"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
-github_project_repo = "https://github.com/google/docsy"
+github_project_repo = "https://github.com/rqlite/rqlite"
 
 # Specify a value here if your content directory is not in your repo's root directory
 # github_subdir = ""


### PR DESCRIPTION
Fixes last modified links at bottom of page, e.g. https://deploy-preview-3--hilarious-dasik-782e38.netlify.app/docs/api/bulk-api/