### PR TITLE
Add contribution-guidelines page

### DIFF
--- a/content/en/docs/contribution-guidelines/_index.md
+++ b/content/en/docs/contribution-guidelines/_index.md
@@ -1,0 +1,9 @@
+---
+title: Contribution Guidelines
+weight: 9
+description: How to contribute to rqlite
+---
+
+rqlite is software, and it goes without saying it can always be improved. It's by no means finished -- issues are tracked, and I plan to develop this project further. Pull requests are welcome, though larger proposals should be discussed first. The design and implementation of rqlite is somewhat opinionated conservative however, so feature and design changes may be slow to become part of rqlite.
+
+rqlite can be compiled and executed on Linux, macOS, and Microsoft Windows.


### PR DESCRIPTION
This PR fixes the unreachable link to the ["Contribution guidelines"](https://rqlite.io/docs/contribution-guidelines/) from the ["Community"](https://rqlite.io/community/) page.

To reproduce, go to https://rqlite.io/community/ and click on "Contribution Guidelines" under "Develop and Contribute".

For now, I have simply copied the contents from https://github.com/rqlite/rqlite/blob/HEAD/CONTRIBUTING.md

Before:

<img width="681" alt="image" src="https://github.com/user-attachments/assets/4384a434-3445-4cda-8a06-531c9537b523" />

After:

<img width="728" alt="image" src="https://github.com/user-attachments/assets/e30869be-5e01-4776-a77f-da526428071b" />
